### PR TITLE
Add OpenThread wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,8 @@ src/jswrap_storage.c \
 src/jswrap_spi_i2c.c \
 src/jswrap_stepper.c \
 src/jswrap_stream.c \
-src/jswrap_waveform.c
+src/jswrap_waveform.c \
+src/jswrap_openthread.c
 endif
 
 # it is important that _pin comes before stuff which uses

--- a/boards/BANGLEJS2.py
+++ b/boards/BANGLEJS2.py
@@ -84,7 +84,8 @@ info = {
      'SOURCES += libs/misc/heartrate_vc31_binary.c', 'DEFINES += -DHEARTRATE_VC31_BINARY=1', 'PRECOMPILED_OBJS += libs/misc/vc31_binary/algo.o libs/misc/vc31_binary/modle5_10.o libs/misc/vc31_binary/modle5_11.o libs/misc/vc31_binary/modle5_12.o libs/misc/vc31_binary/modle5_13.o libs/misc/vc31_binary/modle5_14.o libs/misc/vc31_binary/modle5_15.o libs/misc/vc31_binary/modle5_16.o libs/misc/vc31_binary/modle5_17.o libs/misc/vc31_binary/modle5_18.o libs/misc/vc31_binary/modle5_1.o libs/misc/vc31_binary/modle5_2.o libs/misc/vc31_binary/modle5_3.o libs/misc/vc31_binary/modle5_4.o libs/misc/vc31_binary/modle5_5.o libs/misc/vc31_binary/modle5_6.o libs/misc/vc31_binary/modle5_7.o libs/misc/vc31_binary/modle5_8.o libs/misc/vc31_binary/modle5_9.o',
 # ------------------------
      'SOURCES += libs/misc/unistroke.c',
-     'WRAPPERSOURCES += libs/misc/jswrap_unistroke.c',
+    'WRAPPERSOURCES += libs/misc/jswrap_unistroke.c',
+    'WRAPPERSOURCES += src/jswrap_openthread.c',
      'DEFINES += -DESPR_BANGLE_UNISTROKE=1',
      'SOURCES += libs/banglejs/banglejs2_storage_default.c',
      'DEFINES += -DESPR_STORAGE_INITIAL_CONTENTS=1', # use banglejs2_storage_default

--- a/boards/BANGLEJS2_IFLASH.py
+++ b/boards/BANGLEJS2_IFLASH.py
@@ -93,6 +93,7 @@ info = {
 # ------------------------
      'SOURCES += libs/misc/unistroke.c',
      'WRAPPERSOURCES += libs/misc/jswrap_unistroke.c',
+     'WRAPPERSOURCES += src/jswrap_openthread.c',
      'DEFINES += -DESPR_BANGLE_UNISTROKE=1',
      'SOURCES += libs/banglejs/banglejs2_storage_default.c',
      'DEFINES += -DESPR_STORAGE_INITIAL_CONTENTS=1', # use banglejs2_storage_default

--- a/boards/BANGLEJS2_NOFLASH.py
+++ b/boards/BANGLEJS2_NOFLASH.py
@@ -79,6 +79,7 @@ info = {
 # ------------------------
      'SOURCES += libs/misc/unistroke.c',
      'WRAPPERSOURCES += libs/misc/jswrap_unistroke.c',
+     'WRAPPERSOURCES += src/jswrap_openthread.c',
      'DEFINES += -DESPR_BANGLE_UNISTROKE=1',
      'SOURCES += libs/banglejs/banglejs2_storage_default.c',
      #'DEFINES += -DESPR_STORAGE_INITIAL_CONTENTS=1', # use banglejs2_storage_default

--- a/src/jswrap_openthread.c
+++ b/src/jswrap_openthread.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Espruino, a JavaScript interpreter for Microcontrollers
+ *
+ * Copyright (C) 2025 Codex
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * ----------------------------------------------------------------------------
+ * JavaScript bindings for basic OpenThread functionality
+ * ----------------------------------------------------------------------------
+ */
+#include "jswrap_openthread.h"
+#include "jsvar.h"
+#include "jsinteractive.h"
+
+/*JSON{
+  "type" : "class",
+  "class" : "OpenThread"
+}
+OpenThread interface
+*/
+
+/*JSON{
+  "type" : "method",
+  "class" : "OpenThread",
+  "name" : "init",
+  "generate" : "jswrap_openthread_init"
+}
+Initialise the OpenThread stack
+*/
+void jswrap_openthread_init() {
+  // Normally OpenThread initialisation would happen here
+  jsiConsolePrint("OpenThread init not implemented\n");
+}
+
+/*JSON{
+  "type" : "method",
+  "class" : "OpenThread",
+  "name" : "hello",
+  "generate" : "jswrap_openthread_hello",
+  "return" : ["JsVar","Greeting string"]
+}
+Return a greeting from OpenThread
+*/
+JsVar *jswrap_openthread_hello() {
+  return jsvNewFromString("Hello from OpenThread!");
+}
+
+/*JSON{
+  "type" : "method",
+  "class" : "OpenThread",
+  "name" : "sendHR",
+  "generate" : "jswrap_openthread_sendHR",
+  "params" : [
+    ["bpm","int","Heart rate in beats per minute"]
+  ]
+}
+Send heart rate value via OpenThread
+*/
+void jswrap_openthread_sendHR(JsVarInt bpm) {
+  jsiConsolePrintf("OpenThread sendHR %d\n", (int)bpm);
+}

--- a/src/jswrap_openthread.h
+++ b/src/jswrap_openthread.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of Espruino, a JavaScript interpreter for Microcontrollers
+ *
+ * Copyright (C) 2025 Codex
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * ----------------------------------------------------------------------------
+ * JavaScript bindings for basic OpenThread functionality
+ * ----------------------------------------------------------------------------
+ */
+#ifndef JSWRAP_OPENTHREAD_H_
+#define JSWRAP_OPENTHREAD_H_
+
+#include "jsvar.h"
+
+void jswrap_openthread_init(void);
+JsVar *jswrap_openthread_hello(void);
+void jswrap_openthread_sendHR(JsVarInt bpm);
+
+#endif // JSWRAP_OPENTHREAD_H_


### PR DESCRIPTION
## Summary
- add basic OpenThread wrapper implementation stub
- register wrapper file for Bangle.js 2 builds
- fix Makefile line continuation after wrapper addition
- provide simple `sendHR` stub to demonstrate API usage

## Testing
- `source scripts/provision.sh BANGLEJS2` *(fails: SDK patches fail)*
- `make BOARD=BANGLEJS2` *(fails: arm-none-eabi-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840136293f88322aeda09385b7ae23b